### PR TITLE
Update requirements.txt

### DIFF
--- a/coin_monitor/requirements.txt
+++ b/coin_monitor/requirements.txt
@@ -2,3 +2,4 @@ configparser==5.0.2
 pushbullet.py==0.12.0
 twilio==6.54.0
 Jinja2==2.11.3
+pyyaml==5.4.1


### PR DESCRIPTION
It needs pyyaml, at least in Windows 10 to avoid this error:

```
C:\Users\myuser\repos\chia_plot_manager\coin_monitor>python coin_monitor.py
Traceback (most recent call last):
  File "coin_monitor.py", line 20, in <module>
    from system_logging import setup_logging
  File "C:\Users\myuser\repos\chia_plot_manager\coin_monitor\system_logging.py", line 13, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```